### PR TITLE
Fix regression in unix dialog file filter

### DIFF
--- a/os_files/private_dialog/unix_dialog.nim
+++ b/os_files/private_dialog/unix_dialog.nim
@@ -39,7 +39,7 @@ proc show*(di: DialogInfo): string =
     if di.folder.len > 0:
         discard cast[FileChooser](dialog).setCurrentFolder(di.folder.cstring)
 
-    if not di.filters.len > 0 and di.filters.len > 0:
+    if di.filters.len > 0:
         var filters = newSeq[FileFilter]()
         let all = newFileFilter()
         all.setName("All")


### PR DESCRIPTION
26adc51 altered the conditional for the file dialog filter so the filter never is set. This commit fixes this issue.

26adc51 also changed the filter logic for the windows file dialog. I did not include a fix because I don't have a build environment for windows. I'd be happy to amend the commit though if the same fix is appropriate.